### PR TITLE
[12.0][FIX] project_sla: remove field start_date_sla and return cron in manifest

### DIFF
--- a/project_sla/__manifest__.py
+++ b/project_sla/__manifest__.py
@@ -17,7 +17,7 @@
         "views/project_project.xml",
         "security/ir.model.access.csv",
         # TODO: os métodos utilizados pelo CRON precisam ser revisados
-        # "data/ir_cron_data.xml",
+        "data/ir_cron_data.xml",
     ],
     "demo": [],
 }

--- a/project_sla/models/project_task.py
+++ b/project_sla/models/project_task.py
@@ -201,16 +201,15 @@ class ProjectTask(models.Model):
             .filtered(
                 lambda r: (
                     r.active
-                    and r.team_id.use_sla
-                    and r.create_date >= r.team_id.start_date_sla
+                    and r.project_id.use_sla
                     and (
                         any(not p.reached_date for p in r.sla_line_ids)
                         or not r.sla_line_ids)
                 )
             )
         )
-        for record in recors:
-            lead._sync_sla_lines()
+        for record in records:
+            record._sync_sla_lines()
 
     @api.model
     def cron_sync_all_sla_lines(self):


### PR DESCRIPTION
cc @marcelsavegnago @WesleyOliveira98 @Matthwhy 

Acredito que não faz sentido o `project_sla` depender do campo team_id  referente ao `project_team` para a execução do cron do SLA. Além disso, o campo start_date_sla não existe em ambos os modelos. Sendo assim, adaptei o cron para funcionar corretamente: quando estou no estágio X, ele cria a SLA_Line, e quando alcanço o estágio necessário, ele modifica a SLA Line criada anteriormente com a data em que foi alcançada